### PR TITLE
Better layout on large screens

### DIFF
--- a/js/editor/EditorManager.js
+++ b/js/editor/EditorManager.js
@@ -490,7 +490,7 @@ class EditorManager {
 
         const availableWidth = container.offsetWidth || container.clientWidth || 0;
 
-        const maxCanvasSize = 768;
+        const maxCanvasSize = 512;
         let minCanvasSize = 128;
         const highestDivisor = Math.floor((availableWidth + minCanvasSize - 1) / minCanvasSize) * minCanvasSize;
 

--- a/styles.css
+++ b/styles.css
@@ -311,7 +311,7 @@ body.game-mode #tab-game .game-controls button {
 }
 
 #editor-canvas {
-    width: clamp(128px, 45vw, 768px);
+    width: clamp(128px, 45vw, 512px);
     max-width: 100%;
     height: auto;
 }


### PR DESCRIPTION
## tests on 1900x1060
### Before
<img width="776" height="435" alt="before" src="https://github.com/user-attachments/assets/a9aa452a-2ae7-4408-9fbe-d6988196d712" />

### After
<img width="779" height="437" alt="after" src="https://github.com/user-attachments/assets/62d2fe99-89f3-4a8b-876d-8c4e2a18fe7c" />
