### PR TITLE
Only selects things in the editor that are actually selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                                                 <select id="npc-conditional-reward-variable"></select>
                                             </div>
                                         </div>
-                                        <button id="npc-delete">Deletar NPC</button>
+                                        <button id="npc-delete">Remover NPC</button>
                                     </div>
                                 </div>
                             </details>

--- a/js/editor/EditorManager.js
+++ b/js/editor/EditorManager.js
@@ -131,22 +131,6 @@ class EditorManager {
             this.renderService.updateNpcForm();
         });
 
-        enemyTypes?.addEventListener('click', (ev) => {
-            const card = ev.target.closest('.enemy-card');
-            if (!card) return;
-            const type = card.dataset.type || null;
-            if (!type) return;
-            this.enemyService.selectEnemyType(type);
-        });
-
-        objectTypes?.addEventListener('click', (ev) => {
-            const card = ev.target.closest('.object-type-card');
-            if (!card) return;
-            const type = card.dataset.type || null;
-            if (!type) return;
-            this.objectService.selectObjectType(type);
-        });
-
         btnGenerateUrl?.addEventListener('click', () => this.shareService.generateShareableUrl());
         btnUndo?.addEventListener('click', () => this.undo());
         btnRedo?.addEventListener('click', () => this.redo());
@@ -169,8 +153,9 @@ class EditorManager {
             if (this.state.placingObjectType) {
                 this.objectService.togglePlacement(this.state.placingObjectType, true);
             }
-            this.npcService.clearSelection();
-            this.enemyService.deactivatePlacement();
+
+            this.desselectAllAndRender();
+
             this.selectedTileId = tileId;
             this.renderService.updateSelectedTilePreview();
             this.renderService.renderTileList();
@@ -181,7 +166,21 @@ class EditorManager {
             if (!card) return;
             const type = card.dataset.type || null;
             const id = card.dataset.id || null;
+
+            this.desselectAllAndRender();
+
             this.npcService.updateNpcSelection(type, id);
+        });
+
+        objectTypes?.addEventListener('click', (ev) => {
+            const card = ev.target.closest('.object-type-card');
+            if (!card) return;
+            const type = card.dataset.type || null;
+            if (!type) return;
+            
+            this.desselectAllAndRender();
+
+            this.objectService.selectObjectType(type);
         });
 
         objectsList?.addEventListener('click', (ev) => {
@@ -195,6 +194,17 @@ class EditorManager {
             this.objectService.removeObject(type, room);
         });
 
+        enemyTypes?.addEventListener('click', (ev) => {
+            const card = ev.target.closest('.enemy-card');
+            if (!card) return;
+            const type = card.dataset.type || null;
+            if (!type) return;
+            
+            this.desselectAllAndRender();
+
+            this.enemyService.selectEnemyType(type);
+        });
+
         enemiesList?.addEventListener('click', (ev) => {
             const button = ev.target.closest('[data-remove-enemy]');
             if (!button) return;
@@ -202,6 +212,7 @@ class EditorManager {
             if (!enemyId) return;
             this.enemyService.removeEnemy(enemyId);
         });
+
         enemiesList?.addEventListener('change', (ev) => {
             const target = ev.target;
             if (!target || target.tagName !== 'SELECT') return;
@@ -244,25 +255,18 @@ class EditorManager {
         this.activeRoomIndex = Math.max(0, Math.min(totalRooms - 1, startRoomIndex));
         this.gameEngine.npcManager?.ensureDefaultNPCs?.();
 
-        const enemyDefinitions = EditorConstants.ENEMY_DEFINITIONS;
-        if (enemyDefinitions.length > 0) {
-            const hasCurrent = enemyDefinitions.some((entry) => entry.type === this.selectedEnemyType);
-            if (!hasCurrent) {
-                this.selectedEnemyType = enemyDefinitions[0].type;
-            }
-        }
-
-        const objectDefinitions = EditorConstants.OBJECT_DEFINITIONS;
-        if (objectDefinitions.length > 0) {
-            const hasObjectSelected = objectDefinitions.some((entry) => entry.type === this.selectedObjectType);
-            if (!hasObjectSelected) {
-                this.selectedObjectType = objectDefinitions[0].type;
-            }
-        }
-
         this.renderAll();
         this.handleCanvasResize(true);
         this.history.pushCurrentState();
+    }
+
+    desselectAllAndRender() {
+        this.npcService.clearSelection();
+        this.enemyService.deactivatePlacement();
+        this.state.selectedTileId = null;
+        this.state.selectedEnemyType = null;
+        this.state.selectedObjectType = null;
+        this.renderAll(); // this is not ideal, but will work for now
     }
 
     renderAll() {

--- a/js/editor/modules/EditorState.js
+++ b/js/editor/modules/EditorState.js
@@ -8,7 +8,7 @@ class EditorState {
         this.placingEnemy = false;
         this.placingObjectType = null;
         this.selectedObjectType = null;
-        this.selectedEnemyType = 'giant-rat';
+        this.selectedEnemyType = null;
         this.mapPainting = false;
         this.skipMapHistory = false;
         this.npcTextUpdateTimer = null;

--- a/showcase.html
+++ b/showcase.html
@@ -187,7 +187,7 @@
         <section id="share-section">
             <h2>URL = Jogo Completo</h2>
             <p>
-                Um código curto (ex.: <code>#v7.g...</code>) carrega tiles, mapas, NPCs e estados. Abrir a URL
+                Um código curto no fim da URL (ex.: <code>#v7.g...</code>) carrega tiles, mapas, NPCs e estados. Abrir a URL
                 equivale a importar o jogo completo.
             </p>
             <div class="item-card">
@@ -203,7 +203,7 @@
         <section id="no-install-section">
             <h2>Sem Instalação</h2>
             <p>
-                Não precisa instalar ou baixar nada. Crie seu pequeno RPG direto no navegador.
+                Não precisa instalar ou baixar nada. Crie seu pequeno RPG direto no navegador, até mesmo do celular.
                 Te desafio a montar um RPG em 1 minuto e compartilhar o link.
             </p>
         </section>


### PR DESCRIPTION
This is not an ideal solution, because it renders all menus one extra time. The better approach would be to have a desselect function in every EditorService that just removes the css for selection of whatever has it on.  
But for now this will do.

### Before
![before](https://github.com/user-attachments/assets/bb607b67-2e96-498f-b6c1-885a290aa2d5)

### After
![after](https://github.com/user-attachments/assets/76b1dadd-cb3a-48f7-adc9-db8c466027a6)